### PR TITLE
Fix: Incorrect test case for `substring` function

### DIFF
--- a/test/Test/Lecture1.hs
+++ b/test/Test/Lecture1.hs
@@ -41,7 +41,7 @@ lecture1Spec = describe "Lecture 1" $ do
         it "Bounds are bigger" $ subString 0 100     "Hello!" `shouldBe` "Hello!"
         it "From negative"     $ subString (-1) 3    "Hello!" `shouldBe` "Hell"
         it "Both negative"     $ subString (-7) (-3) "Hello!" `shouldBe` ""
-        it "Negative to zero"  $ subString (-5) 0    "Hello!" `shouldBe` ""
+        it "Negative to zero"  $ subString (-5) 0    "Hello!" `shouldBe` "H"
 
     describe "strSum" $ do
         it "Empty string"           $ strSum ""                   `shouldBe` 0


### PR DESCRIPTION
#### Description
The test case 
```Haskell
it "Negative to zero"  $ subString (-5) 0    "Hello!" `shouldBe` ""
```
is checking for empty string but the second parameter - `0` is considered inclusive in the function definition, so the output to be checked should be `"H"` instead of `""`