### PR TITLE
Fix syntax for comments about import

### DIFF
--- a/src/Lecture1.hs
+++ b/src/Lecture1.hs
@@ -31,9 +31,9 @@ module Lecture1
     , lowerAndGreater
     ) where
 
-{- | VVV If you need to import libraries, do it after this line ... VVV -}
+-- VVV If you need to import libraries, do it after this line ... VVV
 
-{- | ^^^ and before this line. Otherwise the test suite might fail  ^^^ -}
+-- ^^^ and before this line. Otherwise the test suite might fail  ^^^
 
 {- | Specify the type signature of the following function. Think about
 its behaviour, possible types for the function arguments and write the

--- a/src/Lecture2.hs
+++ b/src/Lecture2.hs
@@ -40,9 +40,9 @@ module Lecture2
     , constantFolding
     ) where
 
-{- | VVV If you need to import libraries, do it after this line ... VVV -}
+-- VVV If you need to import libraries, do it after this line ... VVV
 
-{- | ^^^ and before this line. Otherwise the test suite might fail  ^^^ -}
+-- ^^^ and before this line. Otherwise the test suite might fail  ^^^
 
 {- | Implement a function that finds a product of all the numbers in
 the list. But implement a lazier version of this function: if you see

--- a/src/Lecture3.hs
+++ b/src/Lecture3.hs
@@ -34,9 +34,9 @@ module Lecture3
     , apply
     ) where
 
-{- | VVV If you need to import libraries, do it after this line ... VVV -}
+-- VVV If you need to import libraries, do it after this line ... VVV
 
-{- | ^^^ and before this line. Otherwise the test suite might fail  ^^^ -}
+-- ^^^ and before this line. Otherwise the test suite might fail  ^^^
 
 -- $setup
 -- >>> import Data.Semigroup


### PR DESCRIPTION
Right now, if you import libraries between those lines, test suite will fail. 
This syntax change should fix it.
cc @chshersh @vrom911
