### PR TITLE
fix 'Ignores spaces in line' test

### DIFF
--- a/test/Test/Lecture4.hs
+++ b/test/Test/Lecture4.hs
@@ -31,7 +31,7 @@ lecture4Spec = describe "Lecture 4" $ do
             }
 
         it "Ignores spaces in line" $ parseRow "  Apples  ,  Sell  , 7 " `shouldBe` Just Row
-            { rowProduct   = "  Apples  "
+            { rowProduct   = "Apples"
             , rowTradeType = Sell
             , rowCost      = 7
             }


### PR DESCRIPTION
Hello.
Shouldn't we trim spaces when parsing a row?