### PR TITLE
Add tests to `Semigroup`s

### DIFF
--- a/test/Test/Lecture3.hs
+++ b/test/Test/Lecture3.hs
@@ -56,6 +56,8 @@ lecture3Spec = describe "Lecture 3" $ do
     describe "List1" $ do
         it "Laws: Semigroup" $
             lawsCheck (semigroupLaws genList1) `shouldReturn` True
+        it "Includes first element of second list" $
+            List1 1  [2,3] <> List1 4 [5, 6] `shouldBe` List1 1 [2, 3, 4, 5, 6]
 
     describe "Treasure" $ do
         it "Laws: Semigroup" $

--- a/test/Test/Lecture4.hs
+++ b/test/Test/Lecture4.hs
@@ -53,6 +53,12 @@ lecture4Spec = describe "Lecture 4" $ do
     describe "Semigroup: MaxLen" $ do
         it "Laws: Semigroup" $
             lawsCheck (semigroupLaws genMaxLen) `shouldReturn` True
+        it "Right side is Larger" $
+            MaxLen "12345" <> MaxLen "12" `shouldBe` MaxLen "12345"
+        it "Left side is Larger" $
+            MaxLen "12" <> MaxLen "12345" `shouldBe` MaxLen "12345"
+        it "Both sides equal" $
+            MaxLen "abcde" <> MaxLen "12345" `shouldBe` MaxLen "abcde"
 
     describe "Semigroup: Stats" $ do
         it "Laws: Semigroup" $


### PR DESCRIPTION
First test is explained here https://github.com/Flinner/exercises/commit/fb3835cf6cdc1728e3a142811fa90afd93bf7ef7#r65934253

and second is similar to it because the following pass laws

```hs
instance Semigroup MaxLen where
         (<>)  _ b = b
```