### PR TITLE
Removes extra `:` in Lecture 4 stats test case

### DIFF
--- a/test/Test/Lecture4.hs
+++ b/test/Test/Lecture4.hs
@@ -90,7 +90,7 @@ lecture4Spec = describe "Lecture 4" $ do
             }
 
     let stringStats =
-            [ "Total positions:       : 3"
+            [ "Total positions        : 3"
             , "Total final balance    : -15"
             , "Biggest absolute cost  : 50"
             , "Smallest absolute cost : 10"


### PR DESCRIPTION
Removes a superfluous `:` character in the `stringStats` variable in the Lecture 4 Test file