### PR TITLE
Add support for ghc 9.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.6.2.0"]
-        ghc: ["8.10.7"]
+        cabal: ["3.8.1.0"]
+        ghc: ["9.2.5"]
 
     steps:
     - uses: actions/checkout@v3
@@ -61,8 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.7.5"]
-        ghc: ["8.10.7"]
+        stack: ["2.9.3"]
+        ghc: ["9.2.5"]
 
     steps:
     - uses: actions/checkout@v3
@@ -92,8 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.6.2.0"]
-        ghc: ["8.10.7"]
+        cabal: ["3.8.1.0"]
+        ghc: ["9.2.5"]
     steps:
     - uses: actions/checkout@v3
 
@@ -123,8 +123,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.6.2.0"]
-        ghc: ["8.10.7"]
+        cabal: ["3.8.1.0"]
+        ghc: ["9.2.5"]
     steps:
     - uses: actions/checkout@v3
 
@@ -159,8 +159,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.6.2.0"]
-        ghc: ["8.10.7"]
+        cabal: ["3.8.1.0"]
+        ghc: ["9.2.5"]
     steps:
     - uses: actions/checkout@v3
 
@@ -190,8 +190,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.6.2.0"]
-        ghc: ["8.10.7"]
+        cabal: ["3.8.1.0"]
+        ghc: ["9.2.5"]
     steps:
     - uses: actions/checkout@v3
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,8 +14,8 @@ tasks:
       ghcup install cabal 3.6.2.0
       ghcup set cabal 3.6.2.0
       # Install GHC
-      ghcup install ghc 8.10.7
-      ghcup set ghc 8.10.7
+      ghcup install ghc 9.2.5
+      ghcup set ghc 9.2.5
 
     command: |
       # Update cabal

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ To develop in Haskell, you need to install `ghcup`, `ghc` and `cabal`.
    terminal, if these tools are not yet installed.
 
     ```shell
-    ghcup install ghc 8.10.7
-    ghcup set ghc 8.10.7
+    ghcup install ghc 9.2.5
+    ghcup set ghc 9.2.5
     ghcup install cabal 3.6.2.0
     ```
 
@@ -128,7 +128,7 @@ To develop in Haskell, you need to install `ghcup`, `ghc` and `cabal`.
 
     ```shell
     $ ghc --version
-    The Glorious Glasgow Haskell Compilation System, version 8.10.7
+    The Glorious Glasgow Haskell Compilation System, version 9.2.5
     $ cabal --version
     cabal-install version 3.6.2.0
     compiled using version 3.6.2.0 of the Cabal library

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,3 @@
 packages: .
 
 constraints: hedgehog-classes -aeson -semirings -comonad -vector -primitive
-
-source-repository-package
-    type: git
-    location: https://github.com/chshersh/haskell-hedgehog-classes.git
-    tag: 7a46b92ed62cdae73cdca89db28c71a19020c802

--- a/exercises.cabal
+++ b/exercises.cabal
@@ -15,14 +15,14 @@ copyright:           2021-2022 Haskell Beginners 2022 Course
 build-type:          Simple
 extra-doc-files:     README.md
                      CHANGELOG.md
-tested-with:         GHC == 8.10.7
+tested-with:         GHC == 9.2.5
 
 source-repository head
   type:                git
   location:            https://github.com/haskell-beginners-2022/exercises.git
 
 common common-options
-  build-depends:       base ^>= 4.14
+  build-depends:       base >= 4.14 && < 4.17
 
   ghc-options:         -Wall
                        -Wcompat
@@ -96,7 +96,7 @@ test-suite exercises-test
   build-depends:       exercises
                      , hspec            ^>= 2.9
                      , hspec-hedgehog   ^>= 0.0
-                     , hedgehog         ^>= 1.0
+                     , hedgehog         ^>= 1.1
                      , hedgehog-classes ^>= 0.2
                      , silently         ^>= 1.2
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.21
+resolver: lts-20.9
 
 flags:
   hedgehog-classes:


### PR DESCRIPTION
Resolve #87 

- [x] Increase the upper base bound to allow GHC 9.2.4
- [x] Build on CI with 9.2.4 (but only GHC 9.2.4)
- [x] Update the instructions
- [ ] Keep the old lower bound so people who forked the course earlier could still build it with GHC 8.10.7
- [ ] Test locally that it still builds with GHC 8.10.7 just in case

@chshersh  could you please help me how I could keep the old lower bound for 8.10.7 because with this changes it works only with 9.2.4