### PR TITLE
Set up HLint code scanning workflow.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,0 +1,12 @@
+name: Scan code with HLint
+on: [push, pull_request]
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to GitHub code scanning.
+      security-events: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haskell-actions/hlint-scan@v1


### PR DESCRIPTION
After the idea was brought up on the [Haskell Discourse](https://discourse.haskell.org/t/scan-code-with-hlint-for-github-v1-0-0/6151/2?u=chungyc), how could I resist proposing the change?

HLint does suggest [improvements](https://github.com/chungyc/haskell-beginners-exercises/security/code-scanning?query=is%3Aopen+branch%3Ahlint), so there may need to be some [HLint configuration](https://github.com/ndmitchell/hlint/blob/master/README.md#customizing-the-hints) to better fit your preferences, unless you do like HLint's suggestions.

I have invited @chshersh as a collaborator for the forked repository so they can view its [code scanning dashboard](https://github.com/chungyc/haskell-beginners-exercises/security/code-scanning?query=is%3Aopen+branch%3Ahlint).

cc @chshersh
