### PR TITLE
Scan HLint on pull requests.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,5 +1,5 @@
 name: Scan code with HLint
-on: [push]
+on: [push, pull_request]
 
 jobs:
   hlint:


### PR DESCRIPTION
According to https://github.com/orgs/community/discussions/54013, uploading scan results for a pull request no longer requires write permission against the destination repository.  Re-enable HLint code scanning for pull requests, which will also show any warnings and corresponding code in the pull request itself.
